### PR TITLE
fix: match last semver in title; set outputs before API call

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -87,6 +87,19 @@ describe('patch release (x.y.z where z != 0)', () => {
     expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'patch');
     expect(mockSetOutput).toHaveBeenCalledWith('semver',      '2.3.7');
   });
+
+  test('uses the LAST semver in title (Dependabot "from X to Y" style)', async () => {
+    setPRTitle('chore(deps): bump lodash from 2.0.0 to 2.0.1');
+    await run();
+
+    // Should resolve to 2.0.1 (the new version), not 2.0.0 (the old version)
+    expect(mockSetOutput).toHaveBeenCalledWith('semver',      '2.0.1');
+    expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'patch');
+    expect(mockSetOutput).toHaveBeenCalledWith('label',       'patch-release');
+    expect(mockAddLabels).toHaveBeenCalledWith(expect.objectContaining({
+      labels: ['patch-release'],
+    }));
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -139,6 +152,25 @@ describe('custom label overrides', () => {
       labels: ['enhancement'],
     }));
     expect(mockSetOutput).toHaveBeenCalledWith('label', 'enhancement');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Outputs set before API call (survive labeling failures)
+// ---------------------------------------------------------------------------
+describe('outputs survive API failure', () => {
+  test('version outputs are set even when addLabels throws', async () => {
+    mockAddLabels.mockRejectedValueOnce(new Error('Label does not exist'));
+    setPRTitle('Release 1.2.0');
+    await run();
+
+    // Core version outputs must be present despite the API error
+    expect(mockSetOutput).toHaveBeenCalledWith('matched',     'true');
+    expect(mockSetOutput).toHaveBeenCalledWith('semver',      '1.2.0');
+    expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'minor');
+    expect(mockSetOutput).toHaveBeenCalledWith('label',       'minor-release');
+    // The action should still report failure
+    expect(mockSetFailed).toHaveBeenCalledWith('Label does not exist');
   });
 });
 

--- a/index.js
+++ b/index.js
@@ -14,14 +14,16 @@ async function run() {
       return;
     }
 
-    const match = pr.title.match(/\b(\d+)\.(\d+)\.(\d+)\b/);
-    if (!match) {
+    // Use the LAST semver match in the title so that "from X to Y" style titles
+    // (e.g. Dependabot) resolve to the new version (Y) rather than the old one (X).
+    const matches = [...pr.title.matchAll(/\b(\d+)\.(\d+)\.(\d+)\b/g)];
+    if (matches.length === 0) {
       core.info('No semver found in PR title — skipping.');
       core.setOutput('matched', 'false');
       return;
     }
 
-    const [, major, minor, patch] = match;
+    const [, major, minor, patch] = matches[matches.length - 1];
     const semver = `${major}.${minor}.${patch}`;
 
     let semverType;
@@ -32,14 +34,8 @@ async function run() {
     const labelMap   = { major: majorLabel, minor: minorLabel, patch: patchLabel };
     const labelToAdd = labelMap[semverType];
 
-    const octokit = github.getOctokit(token);
-    await octokit.rest.issues.addLabels({
-      owner:        github.context.repo.owner,
-      repo:         github.context.repo.repo,
-      issue_number: pr.number,
-      labels:       [labelToAdd],
-    });
-
+    // Set outputs before the API call so callers always receive version data,
+    // even if the labeling step fails (e.g. label doesn't exist in the repo).
     core.setOutput('matched',     'true');
     core.setOutput('semver',      semver);
     core.setOutput('major',       major);
@@ -47,6 +43,14 @@ async function run() {
     core.setOutput('patch',       patch);
     core.setOutput('semver_type', semverType);
     core.setOutput('label',       labelToAdd);
+
+    const octokit = github.getOctokit(token);
+    await octokit.rest.issues.addLabels({
+      owner:        github.context.repo.owner,
+      repo:         github.context.repo.repo,
+      issue_number: pr.number,
+      labels:       [labelToAdd],
+    });
 
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
Two bugs found during post-merge runtime verification of v2.0.0.

## Bug 1: Double-semver titles matched the wrong version

Dependabot and similar tools generate titles like `"bump lodash from 2.0.0 to 2.0.1"`. The previous regex used `.match()` which returns the **first** occurrence — the old version — leading to the wrong label:

| Title | Before | After |
|---|---|---|
| `bump lodash from 2.0.0 to 2.0.1` | `semver=2.0.0` → **major-release** ❌ | `semver=2.0.1` → **patch-release** ✅ |
| `bump express from 4.18.0 to 4.19.0` | `semver=4.18.0` → minor-release (lucky) | `semver=4.19.0` → **minor-release** ✅ |
| `bump react from 17.0.0 to 18.0.0` | `semver=17.0.0` → major-release (lucky) | `semver=18.0.0` → **major-release** ✅ |

**Fix:** switch from `.match()` to `[...matchAll()]` and take the last entry, so the *to-version* always wins.

```js
// before
const match = pr.title.match(/\b(\d+)\.(\d+)\.(\d+)\b/);

// after — last match wins
const matches = [...pr.title.matchAll(/\b(\d+)\.(\d+)\.(\d+)\b/g)];
const [, major, minor, patch] = matches[matches.length - 1];
```

## Bug 2: Outputs not set when the API call fails

All `core.setOutput()` calls were placed **after** `octokit.rest.issues.addLabels()`. If labeling failed for any reason (label doesn't exist in the repo, token lacks `issues: write` permission, network error), the catch block called `core.setFailed()` and callers received **no outputs at all** — silently skipping any downstream step gating on `steps.semver.outputs.matched`.

**Fix:** move all `setOutput()` calls to **before** the API call so version data is always available regardless of whether labeling succeeds.

```js
// version outputs first — always available to downstream steps
core.setOutput('matched',     'true');
core.setOutput('semver',      semver);
// ...
core.setOutput('label',       labelToAdd);

// labeling is best-effort after outputs are committed
await octokit.rest.issues.addLabels({ ... });
```

## Tests

Two new test cases added (suite: 7 → 9):
- `uses the LAST semver in title (Dependabot "from X to Y" style)`
- `version outputs are set even when addLabels throws`

https://claude.ai/code/session_013MKQT5YEzjQpZZ8hWXvjhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013MKQT5YEzjQpZZ8hWXvjhQ)_