### PR TITLE
feat: pre-release semver support; bump to v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ A reusable GitHub Action that detects a semantic version in a PR title, applies 
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `token` | ✅ | — | GitHub token for API access (`secrets.GITHUB_TOKEN`) |
-| `major_label` | ❌ | `major-release` | Label to apply for major version bumps (e.g. `2.0.0`) |
-| `minor_label` | ❌ | `minor-release` | Label to apply for minor version bumps (e.g. `1.1.0`) |
-| `patch_label` | ❌ | `patch-release` | Label to apply for patch version bumps (e.g. `1.0.1`) |
+| `major_label` | ❌ | `major-release` | Label for major version bumps (e.g. `2.0.0`) |
+| `minor_label` | ❌ | `minor-release` | Label for minor version bumps (e.g. `1.1.0`) |
+| `patch_label` | ❌ | `patch-release` | Label for patch version bumps (e.g. `1.0.1`) |
+| `pre_release_label` | ❌ | `pre-release` | Label for pre-release versions (e.g. `1.2.3-beta.1`, `2.0.0-rc.2`) |
 
 Only `token` is required. Override any label input to match your project's labeling convention.
 
@@ -18,22 +19,30 @@ Only `token` is required. Override any label input to match your project's label
 | Output | Example | Description |
 |---|---|---|
 | `matched` | `"true"` | `"true"` if a semver was found in the PR title, `"false"` otherwise |
-| `semver` | `"2.3.1"` | Full version string extracted from the PR title |
+| `semver` | `"2.3.1-beta.1"` | Full version string including any pre-release identifier |
 | `major` | `"2"` | Major version component |
 | `minor` | `"3"` | Minor version component |
 | `patch` | `"1"` | Patch version component |
-| `semver_type` | `"patch"` | Detected release type: `"major"`, `"minor"`, or `"patch"` |
-| `label` | `"patch-release"` | The label that was applied to the PR |
+| `pre_release` | `"-beta.1"` | Pre-release identifier if present, empty string otherwise |
+| `semver_type` | `"pre-release"` | Release type: `"major"`, `"minor"`, `"patch"`, or `"pre-release"` |
+| `label` | `"pre-release"` | The label that was applied to the PR |
+
+> **Note:** Outputs are always set before the labeling API call, so downstream steps receive version data even if the labeling step itself fails (e.g. the label doesn't exist in the repo yet).
 
 ## Release type detection
 
-The release type is determined from the version string itself:
-
 | Version | `semver_type` |
 |---|---|
+| `x.y.z-<identifier>` (any pre-release suffix) | `pre-release` |
 | `x.y.z` where `z != 0` | `patch` |
 | `x.y.0` where `y != 0` | `minor` |
 | `x.0.0` | `major` |
+
+Pre-release is detected first, so `2.0.0-rc.1` gets `pre-release`, not `major`.
+
+## Dependabot / "from X to Y" titles
+
+When a PR title contains two version strings (e.g. Dependabot's `bump lodash from 2.0.0 to 2.0.1`), the action matches the **last** version found — the new version — so the label always reflects the actual bump.
 
 ## Example usage
 
@@ -65,6 +74,7 @@ jobs:
     major_label: 'breaking-change'
     minor_label: 'enhancement'
     patch_label: 'bug-fix'
+    pre_release_label: 'do-not-merge'
 ```
 
 ### Using outputs in downstream steps
@@ -90,18 +100,25 @@ jobs:
       - name: Log version info
         if: steps.semver.outputs.matched == 'true'
         run: |
-          echo "Version:  ${{ steps.semver.outputs.semver }}"
-          echo "Type:     ${{ steps.semver.outputs.semver_type }}"
-          echo "Label:    ${{ steps.semver.outputs.label }}"
+          echo "Version:     ${{ steps.semver.outputs.semver }}"
+          echo "Type:        ${{ steps.semver.outputs.semver_type }}"
+          echo "Label:       ${{ steps.semver.outputs.label }}"
+          echo "Pre-release: ${{ steps.semver.outputs.pre_release }}"
+
+      - name: Block pre-release merges to main
+        if: steps.semver.outputs.semver_type == 'pre-release'
+        run: |
+          echo "Pre-release detected — blocking merge to main"
+          exit 1
 
       - name: Trigger release pipeline for major bumps
         if: steps.semver.outputs.semver_type == 'major'
-        run: echo "Major release detected — triggering extra checks"
+        run: echo "Major release — running extra checks"
 ```
 
 ## Migration from v1
 
-The `semver_labels` JSON input has been replaced with three individual inputs (`major_label`, `minor_label`, `patch_label`), each with sensible defaults.
+The `semver_labels` JSON input has been replaced with four individual inputs (`major_label`, `minor_label`, `patch_label`, `pre_release_label`), each with sensible defaults.
 
 **v1:**
 ```yaml

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /**
- * Tests for semver-labeling GitHub Action (v2)
+ * Tests for semver-labeling GitHub Action (v2.1)
  *
  * Strategy: mock @actions/core and @actions/github so the action logic
  * can run without a real GitHub context or token.
@@ -31,20 +31,21 @@ jest.mock('@actions/github', () => ({
   context:    mockContext,
 }));
 
-const core        = require('@actions/core');
-const { run }     = require('../index');
+const core    = require('@actions/core');
+const { run } = require('../index');
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function setInputs({ token = 'fake-token', majorLabel, minorLabel, patchLabel } = {}) {
+function setInputs({ token = 'fake-token', majorLabel, minorLabel, patchLabel, preReleaseLabel } = {}) {
   core.getInput.mockImplementation((name) => {
     const map = {
       token,
-      major_label: majorLabel ?? 'major-release',
-      minor_label: minorLabel ?? 'minor-release',
-      patch_label: patchLabel ?? 'patch-release',
+      major_label:       majorLabel       ?? 'major-release',
+      minor_label:       minorLabel       ?? 'minor-release',
+      patch_label:       patchLabel       ?? 'patch-release',
+      pre_release_label: preReleaseLabel  ?? 'pre-release',
     };
     return map[name] ?? '';
   });
@@ -75,6 +76,7 @@ describe('patch release (x.y.z where z != 0)', () => {
     expect(mockSetOutput).toHaveBeenCalledWith('major',       '1');
     expect(mockSetOutput).toHaveBeenCalledWith('minor',       '0');
     expect(mockSetOutput).toHaveBeenCalledWith('patch',       '1');
+    expect(mockSetOutput).toHaveBeenCalledWith('pre_release', '');
     expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'patch');
     expect(mockSetOutput).toHaveBeenCalledWith('label',       'patch-release');
     expect(mockSetFailed).not.toHaveBeenCalled();
@@ -117,6 +119,7 @@ describe('minor release (x.y.0 where y != 0)', () => {
     expect(mockSetOutput).toHaveBeenCalledWith('semver',      '1.2.0');
     expect(mockSetOutput).toHaveBeenCalledWith('patch',       '0');
     expect(mockSetOutput).toHaveBeenCalledWith('minor',       '2');
+    expect(mockSetOutput).toHaveBeenCalledWith('pre_release', '');
     expect(mockSetFailed).not.toHaveBeenCalled();
   });
 });
@@ -135,7 +138,67 @@ describe('major release (x.0.0)', () => {
     expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'major');
     expect(mockSetOutput).toHaveBeenCalledWith('semver',      '2.0.0');
     expect(mockSetOutput).toHaveBeenCalledWith('major',       '2');
+    expect(mockSetOutput).toHaveBeenCalledWith('pre_release', '');
     expect(mockSetFailed).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-release versions
+// ---------------------------------------------------------------------------
+describe('pre-release versions', () => {
+  test('beta pre-release: sets semver_type=pre-release and pre_release output', async () => {
+    setPRTitle('Release 1.2.3-beta.1');
+    await run();
+
+    expect(mockAddLabels).toHaveBeenCalledWith(expect.objectContaining({
+      labels: ['pre-release'],
+    }));
+    expect(mockSetOutput).toHaveBeenCalledWith('semver',      '1.2.3-beta.1');
+    expect(mockSetOutput).toHaveBeenCalledWith('major',       '1');
+    expect(mockSetOutput).toHaveBeenCalledWith('minor',       '2');
+    expect(mockSetOutput).toHaveBeenCalledWith('patch',       '3');
+    expect(mockSetOutput).toHaveBeenCalledWith('pre_release', '-beta.1');
+    expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'pre-release');
+    expect(mockSetOutput).toHaveBeenCalledWith('label',       'pre-release');
+    expect(mockSetFailed).not.toHaveBeenCalled();
+  });
+
+  test('rc pre-release: 2.0.0-rc.2', async () => {
+    setPRTitle('Release 2.0.0-rc.2');
+    await run();
+
+    expect(mockSetOutput).toHaveBeenCalledWith('semver',      '2.0.0-rc.2');
+    expect(mockSetOutput).toHaveBeenCalledWith('pre_release', '-rc.2');
+    expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'pre-release');
+  });
+
+  test('alpha pre-release without dot-number: 1.0.0-alpha', async () => {
+    setPRTitle('Release 1.0.0-alpha');
+    await run();
+
+    expect(mockSetOutput).toHaveBeenCalledWith('semver',      '1.0.0-alpha');
+    expect(mockSetOutput).toHaveBeenCalledWith('pre_release', '-alpha');
+    expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'pre-release');
+  });
+
+  test('custom pre_release_label override', async () => {
+    setInputs({ preReleaseLabel: 'do-not-merge' });
+    setPRTitle('Release 2.0.0-rc.1');
+    await run();
+
+    expect(mockAddLabels).toHaveBeenCalledWith(expect.objectContaining({
+      labels: ['do-not-merge'],
+    }));
+    expect(mockSetOutput).toHaveBeenCalledWith('label', 'do-not-merge');
+  });
+
+  test('Dependabot pre-release: last version wins', async () => {
+    setPRTitle('chore(deps): bump lib from 1.0.0 to 2.0.0-beta.1');
+    await run();
+
+    expect(mockSetOutput).toHaveBeenCalledWith('semver',      '2.0.0-beta.1');
+    expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'pre-release');
   });
 });
 
@@ -164,12 +227,10 @@ describe('outputs survive API failure', () => {
     setPRTitle('Release 1.2.0');
     await run();
 
-    // Core version outputs must be present despite the API error
     expect(mockSetOutput).toHaveBeenCalledWith('matched',     'true');
     expect(mockSetOutput).toHaveBeenCalledWith('semver',      '1.2.0');
     expect(mockSetOutput).toHaveBeenCalledWith('semver_type', 'minor');
     expect(mockSetOutput).toHaveBeenCalledWith('label',       'minor-release');
-    // The action should still report failure
     expect(mockSetFailed).toHaveBeenCalledWith('Label does not exist');
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -20,19 +20,25 @@ inputs:
     description: 'Label to apply for patch version bumps (e.g. 1.0.1). Defaults to "patch-release".'
     required: false
     default: 'patch-release'
+  pre_release_label:
+    description: 'Label to apply for pre-release versions (e.g. 1.2.3-beta.1, 2.0.0-rc.2). Defaults to "pre-release".'
+    required: false
+    default: 'pre-release'
 outputs:
   matched:
     description: "'true' if a semver string was found in the PR title, 'false' otherwise"
   semver:
-    description: "Full version string found in the PR title (e.g. '2.3.1')"
+    description: "Full version string found in the PR title including any pre-release identifier (e.g. '2.3.1', '2.3.1-beta.1')"
   major:
     description: "Major version component"
   minor:
     description: "Minor version component"
   patch:
     description: "Patch version component"
+  pre_release:
+    description: "Pre-release identifier if present, empty string otherwise (e.g. '-beta.1', '-rc.2')"
   semver_type:
-    description: "Detected release type: 'major', 'minor', or 'patch'"
+    description: "Detected release type: 'major', 'minor', 'patch', or 'pre-release'"
   label:
     description: "The label that was applied to the PR"
 runs:

--- a/index.js
+++ b/index.js
@@ -3,10 +3,11 @@ const github = require('@actions/github');
 
 async function run() {
   try {
-    const token      = core.getInput('token');
-    const majorLabel = core.getInput('major_label');
-    const minorLabel = core.getInput('minor_label');
-    const patchLabel = core.getInput('patch_label');
+    const token           = core.getInput('token');
+    const majorLabel      = core.getInput('major_label');
+    const minorLabel      = core.getInput('minor_label');
+    const patchLabel      = core.getInput('patch_label');
+    const preReleaseLabel = core.getInput('pre_release_label');
 
     const pr = github.context.payload.pull_request;
     if (!pr) {
@@ -14,24 +15,34 @@ async function run() {
       return;
     }
 
-    // Use the LAST semver match in the title so that "from X to Y" style titles
-    // (e.g. Dependabot) resolve to the new version (Y) rather than the old one (X).
-    const matches = [...pr.title.matchAll(/\b(\d+)\.(\d+)\.(\d+)\b/g)];
+    // Match full semver strings including optional pre-release identifiers
+    // (e.g. 1.2.3, 1.2.3-beta.1, 2.0.0-rc.2). Use the LAST match in the
+    // title so "from X to Y" style titles (e.g. Dependabot) resolve to the
+    // new version (Y) rather than the old one (X).
+    const matches = [...pr.title.matchAll(/\b(\d+)\.(\d+)\.(\d+)(-[a-zA-Z0-9][a-zA-Z0-9.-]*)?\b/g)];
     if (matches.length === 0) {
       core.info('No semver found in PR title — skipping.');
       core.setOutput('matched', 'false');
       return;
     }
 
-    const [, major, minor, patch] = matches[matches.length - 1];
-    const semver = `${major}.${minor}.${patch}`;
+    const [, major, minor, patch, preRelease] = matches[matches.length - 1];
+    const semver = preRelease
+      ? `${major}.${minor}.${patch}${preRelease}`
+      : `${major}.${minor}.${patch}`;
 
     let semverType;
-    if (patch !== '0')      semverType = 'patch';
+    if (preRelease)         semverType = 'pre-release';
+    else if (patch !== '0') semverType = 'patch';
     else if (minor !== '0') semverType = 'minor';
     else                    semverType = 'major';
 
-    const labelMap   = { major: majorLabel, minor: minorLabel, patch: patchLabel };
+    const labelMap = {
+      major:         majorLabel,
+      minor:         minorLabel,
+      patch:         patchLabel,
+      'pre-release': preReleaseLabel,
+    };
     const labelToAdd = labelMap[semverType];
 
     // Set outputs before the API call so callers always receive version data,
@@ -41,6 +52,7 @@ async function run() {
     core.setOutput('major',       major);
     core.setOutput('minor',       minor);
     core.setOutput('patch',       patch);
+    core.setOutput('pre_release', preRelease ?? '');
     core.setOutput('semver_type', semverType);
     core.setOutput('label',       labelToAdd);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semver-labeling",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "GitHub Action to detect a semantic version in a PR title, apply a label, and expose parsed version data as outputs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What's new

### Pre-release version support

The action now detects and handles pre-release semver identifiers like `1.2.3-beta.1`, `2.0.0-rc.2`, `1.0.0-alpha`, etc.

**New input:**

| Input | Default | Description |
|---|---|---|
| `pre_release_label` | `pre-release` | Label to apply for pre-release versions |

**New output:**

| Output | Example | Description |
|---|---|---|
| `pre_release` | `"-beta.1"` | Pre-release identifier if present, empty string otherwise |

**Updated `semver_type`** — now has four possible values: `major`, `minor`, `patch`, `pre-release`.

Pre-release is checked first, so `2.0.0-rc.1` gets `semver_type=pre-release` (not `major`).

### Example

```yaml
- name: Block pre-release merges to main
  if: steps.semver.outputs.semver_type == 'pre-release'
  run: |
    echo "Pre-release ${{ steps.semver.outputs.semver }} detected"
    exit 1
```

### Custom label override

```yaml
with:
  token: ${{ secrets.GITHUB_TOKEN }}
  pre_release_label: 'do-not-merge'
```

---

## Version bump: 2.0.0 → 2.1.0

This is a minor version bump (new feature, fully backwards compatible — existing callers without `pre_release_label` get the `pre-release` default and any existing standard version titles are unaffected).

---

## Tests

5 new test cases added (suite: 9 → 14):
- `beta pre-release: sets semver_type=pre-release and pre_release output`
- `rc pre-release: 2.0.0-rc.2`
- `alpha pre-release without dot-number: 1.0.0-alpha`
- `custom pre_release_label override`
- `Dependabot pre-release: last version wins`

https://claude.ai/code/session_013MKQT5YEzjQpZZ8hWXvjhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013MKQT5YEzjQpZZ8hWXvjhQ)_