### PR TITLE
chore: update package-lock.json after jest install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semver-labeling",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semver-labeling",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",


### PR DESCRIPTION
Updates `package-lock.json` to reflect the jest devDependency added in v2.0.0. The lockfile was updated locally during testing but wasn't included in the original commit.

https://claude.ai/code/session_013MKQT5YEzjQpZZ8hWXvjhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013MKQT5YEzjQpZZ8hWXvjhQ)_